### PR TITLE
hu könyvtárban legyenek a fordítások

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -185,7 +185,7 @@ The `ShouldBroadcast` interface requires you to implement a single method: `broa
     use Illuminate\Broadcasting\InteractsWithSockets;
     use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
-    class ServerCreated extends Event implements ShouldBroadcast
+    class ServerCreated implements ShouldBroadcast
     {
         use SerializesModels;
 

--- a/database.md
+++ b/database.md
@@ -7,7 +7,6 @@
 - [Running Raw SQL Queries](#running-queries)
     - [Listening For Query Events](#listening-for-query-events)
 - [Database Transactions](#database-transactions)
-- [Using Multiple Database Connections](#accessing-connections)
 
 <a name="introduction"></a>
 ## Introduction

--- a/eloquent.md
+++ b/eloquent.md
@@ -304,7 +304,7 @@ Updates can also be performed against any number of models that match a given qu
 
 The `update` method expects an array of column and value pairs representing the columns that should be updated.
 
-> {note} When issuing a mass update via Eloquent, the `saved` and `updated` model events will be not be fired for the updated models. This is because the models are never actually retrieved when issuing a mass update.
+> {note} When issuing a mass update via Eloquent, the `saved` and `updated` model events will not be fired for the updated models. This is because the models are never actually retrieved when issuing a mass update.
 
 <a name="mass-assignment"></a>
 ### Mass Assignment

--- a/hu/readme.md
+++ b/hu/readme.md
@@ -1,0 +1,9 @@
+# Magyar Laravel Dokumentáció
+
+## Fordítás beküldése
+
+A fordításokat pull request formájában küldjétek, mindig az aktuális (jelenleg 5.3) verziónak megfelelő branchre.
+
+## Fordítási irányelvek
+
+Lásd a [wikit](https://github.com/laravelhungary/docs/wiki/Kifejez%C3%A9sek).

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,5 @@
-# Magyar Laravel Dokumentáció
+# Laravel Documentation
 
-## Fordítás beküldése
+## Contribution Guidelines
 
-A fordításokat pull request formájában küldjétek, mindig az aktuális (jelenleg 5.3) verziónak megfelelő branchre.
-
-## Fordítási irányelvek
-
-Lásd a [wikit](https://github.com/laravelhungary/docs/wiki/Kifejez%C3%A9sek).
+If you are submitting documentation for the **current stable release**, submit it to the corresponding branch. For example, documentation for Laravel 5.1 would be submitted to the `5.1` branch. Documentation intended for the next release of Laravel should be submitted to the `master` branch.

--- a/session.md
+++ b/session.md
@@ -59,7 +59,7 @@ You may use the `session:table` Artisan command to generate this migration:
 
 #### Redis
 
-Before using Redis sessions with Laravel, you will need to install the `predis/predis` package (~1.0) via Composer. You may configure your Redis connections in the `database` configuration file. In the `session` configuration file, the `database` option may be used to specify which Redis connection is used by the session.
+Before using Redis sessions with Laravel, you will need to install the `predis/predis` package (~1.0) via Composer. You may configure your Redis connections in the `database` configuration file. In the `session` configuration file, the `connection` option may be used to specify which Redis connection is used by the session.
 
 <a name="using-the-session"></a>
 ## Using The Session

--- a/upgrade.md
+++ b/upgrade.md
@@ -450,7 +450,7 @@ If a form request's validation fails, Laravel will now throw an instance of `Ill
 When validating arrays, booleans, integers, numerics, and strings, `null` will no longer be considered a valid value unless the rule set contains the new `nullable` rule:
 
     Validate::make($request->all(), [
-        'string' => 'nullable|max:5',
+        'field' => 'nullable|max:5',
     ]);
 
 <a name="upgrade-5.2.0"></a>

--- a/upgrade.md
+++ b/upgrade.md
@@ -367,7 +367,9 @@ In your queue configuration, all `expire` configuration items should be renamed 
 
 #### Closures
 
-Queueing closures is no longer supported. If you are queueing a Closure in your application, you should convert the Closure to a class and queue an instance of the class instead.
+Queueing closures is no longer supported. If you are queueing a closure in your application, you should convert the dispatched closure to a class and queue an instance of it instead, like the following:
+
+    dispatch(new ProcessPodcast($podcast));
 
 #### Collection Serialization
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -391,7 +391,9 @@ Various queue job events such as `JobProcessing` and `JobProcessed` no longer co
 
 #### Jobs Table
 
-If you are using the `database` driver, you should drop the `jobs_queue_reserved_reserved_at_index` index then drop the `reserved` column from your `jobs` table. This column is no longer required when using the `database` driver. Once you have completed these changes, you should add a new compound index on the `queue` and `reserved_at` column.
+If you are using the `database` driver to store your queued jobs in `config/queue.php`, you should drop the `jobs_queue_reserved_reserved_at_index` index then drop the `reserved` column from your `jobs` table. This column is no longer required when using the `database` driver. Once you have completed these changes, you should add a new compound index on the `queue` and `reserved_at` column, using a SQL query like:
+
+    `CREATE INDEX queue_reserved_at on jobs (queue, reserved_at);`
 
 #### Failed Jobs Table
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -387,7 +387,7 @@ In your queue configuration, all `expire` configuration items should be renamed 
 
 #### Closures
 
-Queueing closures is no longer supported. If you are queueing a closure in your application, you should convert the dispatched closure to a class and queue an instance of it instead, like the following:
+Queueing Closures is no longer supported. If you are queueing a Closure in your application, you should convert the Closure to a class and queue an instance of the class:
 
     dispatch(new ProcessPodcast($podcast));
 
@@ -411,9 +411,7 @@ Various queue job events such as `JobProcessing` and `JobProcessed` no longer co
 
 #### Jobs Table
 
-If you are using the `database` driver to store your queued jobs in `config/queue.php`, you should drop the `jobs_queue_reserved_reserved_at_index` index then drop the `reserved` column from your `jobs` table. This column is no longer required when using the `database` driver. Once you have completed these changes, you should add a new compound index on the `queue` and `reserved_at` column, using a SQL query like:
-
-    `CREATE INDEX queue_reserved_at on jobs (queue, reserved_at);`
+If you are using the `database` driver to store your queued jobs in `config/queue.php`, you should drop the `jobs_queue_reserved_reserved_at_index` index then drop the `reserved` column from your `jobs` table. This column is no longer required when using the `database` driver. Once you have completed these changes, you should add a new compound index on the `queue` and `reserved_at` columns.
 
 #### Failed Jobs Table
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -435,7 +435,7 @@ If you would like to maintain the previous behavior instead of automatically sin
 
 URL prefixes no longer affect the route names assigned to routes when using `Route::resource`, since this behavior defeated the entire purpose of using route names in the first place.
 
-If your application is using `Route::resource` within a `Route::group` call that specified a `prefix` option, you should examine all of your calls to the `route` helper and verify that you are no longer appending the URI `prefix` to the route name.
+If your application is using `Route::resource` within a `Route::group` call that specified a `prefix` option, you should examine all of your `route` helper and `UrlGenerator::route` calls to verify that you are no longer appending this URI prefix to the route name.
 
 If this change causes you to have two routes with the same name, you may use the `names` option when calling `Route::resource` to specify a custom name for a given route. Refer to the [resource routing documentation](/docs/5.3/controllers#resource-controllers) for more information.
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -153,11 +153,11 @@ The `first`, `last`, and `contains` collection methods all pass the "value" as t
 
 In previous versions of Laravel, the `$key` was passed first. Since most use cases are only interested in the `$value` it is now passed first. You should do a "global find" in your application for these methods to verify that you are expecting the `$value` to be passed as the first argument to your Closure.
 
-#### `where` Comparison Now "Loose" By Default
+#### Collection `where` Comparison Methods Are "Loose" By Default
 
-The `where` method now performs a "loose" comparison by default instead of a strict comparison. If you would like to perform a strict comparison, you may use the `whereStrict` method.
+A collection's `where` method now performs a "loose" comparison by default instead of a strict comparison. If you would like to perform a strict comparison, you may use the `whereStrict` method.
 
-The `where` method also no longer accepts a third parameter to indicate "strictness". You should explicit call either `where` or `whereStrict` depending on your application's needs.
+The `where` method also no longer accepts a third parameter to indicate "strictness." You should explicitly call either `where` or `whereStrict` depending on your application's needs.
 
 ### Controllers
 


### PR DESCRIPTION
Jelenelg az eredeti fájlokat írjuk át és úgy fordítunk. Ezzel az a gond, hogy ha változik az eredeti fájl, akkor azt nem, vagy csak nehézkesen tudjuk követni. Azt javaslom, hogy tegyük a magyar fájlokat a hu könyvtárba, így tudjuk majd mergelni a hivatalos doksi változásait. (ezt meg is tettem ebben a pull requestben)
